### PR TITLE
Implement Solapi-based CoffeeChat form

### DIFF
--- a/coffeeChat/build.gradle
+++ b/coffeeChat/build.gradle
@@ -18,9 +18,14 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+        implementation 'org.springframework.boot:spring-boot-starter-web'
+        implementation 'org.apache.tomcat.embed:tomcat-embed-jasper'
+        implementation 'jakarta.servlet:jakarta.servlet-api'
+        implementation 'jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api'
+        runtimeOnly 'org.glassfish.web:jakarta.servlet.jsp.jstl'
+
+        testImplementation 'org.springframework.boot:spring-boot-starter-test'
+        testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/coffeeChat/src/main/java/com/backend/coffeeChat/controller/CoffeeChatController.java
+++ b/coffeeChat/src/main/java/com/backend/coffeeChat/controller/CoffeeChatController.java
@@ -1,0 +1,58 @@
+package com.backend.coffeeChat.controller;
+
+import com.backend.coffeeChat.dto.ApplyRequest;
+import com.backend.coffeeChat.repository.ApplicationRepository;
+import com.backend.coffeeChat.service.AlimtalkService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Controller
+public class CoffeeChatController {
+
+    private final ApplicationRepository repository;
+    private final AlimtalkService alimtalkService;
+
+    public CoffeeChatController(ApplicationRepository repository, AlimtalkService alimtalkService) {
+        this.repository = repository;
+        this.alimtalkService = alimtalkService;
+    }
+
+    @GetMapping("/apply")
+    public String applyForm(Model model) {
+        model.addAttribute("applyRequest", new ApplyRequest());
+        return "apply";
+    }
+
+    @PostMapping("/apply")
+    public String apply(@ModelAttribute ApplyRequest applyRequest) {
+        ApplyRequest saved = repository.save(applyRequest);
+        // Send notification to admin with accept link
+        Map<String, String> vars = new HashMap<>();
+        vars.put("name", saved.getName());
+        vars.put("time", saved.getPreferredTime());
+        vars.put("topic", saved.getTopic());
+        vars.put("acceptUrl", "https://your.server/accept?id=" + saved.getId());
+        alimtalkService.sendAlimtalk("ADMIN_PHONE", "TEMPLATE_ADMIN", vars);
+        return "redirect:/apply";
+    }
+
+    @GetMapping("/accept")
+    public String accept(@RequestParam("id") Long id) {
+        ApplyRequest request = repository.findById(id);
+        if (request != null) {
+            Map<String, String> vars = new HashMap<>();
+            vars.put("name", request.getName());
+            vars.put("time", request.getPreferredTime());
+            vars.put("topic", request.getTopic());
+            alimtalkService.sendAlimtalk(request.getContact(), "TEMPLATE_USER_ACCEPT", vars);
+        }
+        return "accept"; // a simple JSP message page (could be created)
+    }
+}

--- a/coffeeChat/src/main/java/com/backend/coffeeChat/dto/ApplyRequest.java
+++ b/coffeeChat/src/main/java/com/backend/coffeeChat/dto/ApplyRequest.java
@@ -1,0 +1,49 @@
+package com.backend.coffeeChat.dto;
+
+public class ApplyRequest {
+    private Long id;
+    private String name;
+    private String contact;
+    private String preferredTime;
+    private String topic;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getContact() {
+        return contact;
+    }
+
+    public void setContact(String contact) {
+        this.contact = contact;
+    }
+
+    public String getPreferredTime() {
+        return preferredTime;
+    }
+
+    public void setPreferredTime(String preferredTime) {
+        this.preferredTime = preferredTime;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+}

--- a/coffeeChat/src/main/java/com/backend/coffeeChat/repository/ApplicationRepository.java
+++ b/coffeeChat/src/main/java/com/backend/coffeeChat/repository/ApplicationRepository.java
@@ -1,0 +1,25 @@
+package com.backend.coffeeChat.repository;
+
+import com.backend.coffeeChat.dto.ApplyRequest;
+import org.springframework.stereotype.Repository;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+@Repository
+public class ApplicationRepository {
+    private final Map<Long, ApplyRequest> store = new ConcurrentHashMap<>();
+    private final AtomicLong idGenerator = new AtomicLong(1);
+
+    public ApplyRequest save(ApplyRequest request) {
+        long id = idGenerator.getAndIncrement();
+        request.setId(id);
+        store.put(id, request);
+        return request;
+    }
+
+    public ApplyRequest findById(Long id) {
+        return store.get(id);
+    }
+}

--- a/coffeeChat/src/main/java/com/backend/coffeeChat/service/AlimtalkService.java
+++ b/coffeeChat/src/main/java/com/backend/coffeeChat/service/AlimtalkService.java
@@ -1,0 +1,41 @@
+package com.backend.coffeeChat.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class AlimtalkService {
+    @Value("${solapi.api.key:YOUR_API_KEY}")
+    private String apiKey;
+
+    @Value("${solapi.api.secret:YOUR_API_SECRET}")
+    private String apiSecret;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public void sendAlimtalk(String to, String templateCode, Map<String, String> variables) {
+        // Construct request body for Solapi.
+        Map<String, Object> body = new HashMap<>();
+        body.put("to", to);
+        body.put("templateId", templateCode);
+        body.put("kakaoOptions", Map.of("variables", variables));
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("Authorization", "HMAC " + apiKey + ":" + apiSecret);
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(body, headers);
+
+        // Actual API endpoint may differ.
+        String url = "https://api.solapi.com/messages/v4/send";
+        restTemplate.exchange(url, HttpMethod.POST, entity, String.class);
+    }
+}

--- a/coffeeChat/src/main/resources/application.properties
+++ b/coffeeChat/src/main/resources/application.properties
@@ -1,1 +1,8 @@
 spring.application.name=coffeeChat
+
+spring.mvc.view.prefix=/WEB-INF/jsp/
+spring.mvc.view.suffix=.jsp
+
+# Solapi credentials
+solapi.api.key=YOUR_API_KEY
+solapi.api.secret=YOUR_API_SECRET

--- a/coffeeChat/src/main/webapp/WEB-INF/jsp/accept.jsp
+++ b/coffeeChat/src/main/webapp/WEB-INF/jsp/accept.jsp
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Application Accepted</title>
+</head>
+<body>
+<h2>Your application has been processed.</h2>
+</body>
+</html>

--- a/coffeeChat/src/main/webapp/WEB-INF/jsp/apply.jsp
+++ b/coffeeChat/src/main/webapp/WEB-INF/jsp/apply.jsp
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Coffee Chat Application</title>
+</head>
+<body>
+<h1>Apply for Coffee Chat</h1>
+<form action="/apply" method="post">
+    <label for="name">Name:</label>
+    <input type="text" id="name" name="name" required><br>
+
+    <label for="contact">Contact:</label>
+    <input type="text" id="contact" name="contact" required><br>
+
+    <label for="time">Preferred Time:</label>
+    <input type="text" id="time" name="preferredTime" required><br>
+
+    <label for="topic">Topic:</label>
+    <input type="text" id="topic" name="topic" required><br>
+
+    <button type="submit">Apply</button>
+</form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add JSP form for coffee chat application
- configure view resolver and Solapi properties
- implement DTO and in-memory repository
- create Alimtalk service for calling Solapi
- build controller endpoints for `/apply` and `/accept`
- include JSP page for simple acceptance notice
- add web and JSP related dependencies

## Testing
- `./gradlew test -q` *(fails: Unable to download Gradle wrapper due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686340bb9c48832998351ed732d08a7e