### PR TITLE
Add sample configuration and setup instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Ignore IDE or build tool directories
+/build
+.gradle
+/out
+
+# Ignore actual application properties containing credentials
+coffeeChat/src/main/resources/application.properties

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# CoffeeChat
+
+This project is a Spring Boot application for managing CoffeeChat application forms using Solapi.
+
+## Configuration
+
+Configuration values such as Solapi API credentials are expected in an `application.properties` file located in `coffeeChat/src/main/resources`.
+
+1. Copy `application-sample.properties` and name the copy `application.properties`:
+   
+   ```bash
+   cp coffeeChat/src/main/resources/application-sample.properties \
+      coffeeChat/src/main/resources/application.properties
+   ```
+2. Edit the new `application.properties` file and replace the placeholder values with your actual credentials.
+
+The repository ignores `application.properties`, so your private credentials remain local.
+
+## Building
+
+Use Gradle Wrapper to build the project:
+
+```bash
+./gradlew build
+```
+

--- a/coffeeChat/src/main/resources/application-sample.properties
+++ b/coffeeChat/src/main/resources/application-sample.properties
@@ -1,0 +1,8 @@
+spring.application.name=coffeeChat
+
+spring.mvc.view.prefix=/WEB-INF/jsp/
+spring.mvc.view.suffix=.jsp
+
+# Solapi credentials
+solapi.api.key=YOUR_API_KEY
+solapi.api.secret=YOUR_API_SECRET


### PR DESCRIPTION
## Summary
- create `application-sample.properties` with placeholder credentials
- ignore user specific `application.properties`
- add README with instructions for copying the sample file

## Testing
- `./gradlew test` *(fails: unable to fetch Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686343b3ab908329bc1175f159789836